### PR TITLE
🐛 fix: convert repository names to lowercase for Docker compatibility

### DIFF
--- a/bin/postal
+++ b/bin/postal
@@ -41,6 +41,10 @@ run() {
     fi
 }
 
+docker-safe-name() {
+    echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 ORIGINAL_ARGS="${@:2}"
 POSITIONAL_ARGS=()
 while [[ $# -gt 0 ]]; do
@@ -131,10 +135,11 @@ set-postal-version() {
 
     # If using custom repo, replace the image name in docker-compose.yml
     if [ "$GITHUB_REPO" != "postalserver/postal" ]; then
-        # Use branch as tag for custom repos
+        # Convert to Docker-safe naming (lowercase)
+        docker_repo=$(docker-safe-name "$GITHUB_REPO")
         custom_tag="$GITHUB_BRANCH"
         # Replace default image with custom repo image using branch as tag
-        $SED -i "s|postalserver/postal:$desired_version|$GITHUB_REPO:$custom_tag|" docker-compose.yml
+        $SED -i "s|postalserver/postal:$desired_version|$docker_repo:$custom_tag|" docker-compose.yml
     fi
 
     call-hook "set-postal-version"


### PR DESCRIPTION
## 🎯 Problem
The postal-install script generates invalid Docker image names when using GitHub repositories with CamelCase names. Docker Hub requires completely lowercase image names, but the current implementation preserves the original case from GitHub URLs.

## 🚀 What This PR Fixes
Converts GitHub repository names with uppercase letters to lowercase when generating Docker image references, ensuring compatibility with Docker Hub naming requirements.

## 🔧 Changes Made
- ✅ Add `docker-safe-name()` function to handle case conversion
- ✅ Update `set-postal-version()` to use lowercase image names in docker-compose.yml
- ✅ Maintain backward compatibility with existing lowercase repositories
- ✅ Preserve original GitHub repository references for git operations

## 📋 Before & After

### Before (Broken)
```bash
GITHUB_URL=https://github.com/PhishSpot/PostalServer
# Generates invalid Docker image: PhishSpot/PostalServer:main ❌
```

### After (Fixed)
```bash
GITHUB_URL=https://github.com/PhishSpot/PostalServer
# Generates valid Docker image: phishspot/postalserver:main ✅
```

## 🔄 Technical Implementation
```bash
docker-safe-name() {
    echo "$1" | tr '[:upper:]' '[:lower:]'
}

# Usage in set-postal-version()
docker_repo=$(docker-safe-name "$GITHUB_REPO")
$SED -i "s|postalserver/postal:$desired_version|$docker_repo:$custom_tag|" docker-compose.yml
```

## 📝 Files Modified
- `bin/postal` - Added docker-safe-name function and updated Docker image generation

## 🔒 Backward Compatibility
- ✅ Existing installations with lowercase repositories continue to work
- ✅ No breaking changes to existing functionality
- ✅ All current commands and workflows preserved